### PR TITLE
Replace hardcoded laser interval with constant

### DIFF
--- a/js/hero.js
+++ b/js/hero.js
@@ -53,7 +53,7 @@ function shoot() {
 
   gLaserInterval = setInterval(() => {
     blinkLaser(currLaserPose);
-  }, 200);
+  }, LASER_SPEED);
 }
 
 function blinkLaser(pos) {


### PR DESCRIPTION
## Summary
- use the `LASER_SPEED` constant for the laser timer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68848d085a68832cb999b3e5b3d161e7